### PR TITLE
Migrate to fly.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# flyctl launch added from .gitignore
+**/pom.xml
+**/pom.xml.asc
+**/*.jar
+**/*.class
+lib
+classes
+target
+checkouts
+**/.lein-deps-sum
+**/.lein-repl-history
+**/.lein-plugins
+**/.lein-failures
+**/.nrepl-port
+**/.cpcache
+**/*.pdf
+**/*.tex
+**/.auctex-auto/*
+**/_minted-report/*
+**/_minted-README/*
+**/public/js/*
+**/node_modules/*
+**/resources/public/*
+**/.shadow-cljs/*
+**/out/*
+fly.toml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "18"
 
       - name: install dependencies
         run: yarn install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,10 @@ jobs:
       - name: build reljr
         run: yarn shadow-cljs release reljr
 
-      - name: Copying files to server
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          password: ${{ secrets.REMOTE_USER_PASSWORD }}
-          rm: true
-          source: "public/index.html,public/css/main.css,public/js/main.js"
-          strip_components: 1
-          target: "${{ secrets.REMOTE_DIR }}"
+      - name: Setup deploy environment
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM clojure:temurin-17-alpine AS build
+
+WORKDIR /app
+COPY . /app
+
+RUN apk update && \
+    apk add --update nodejs npm && \
+    npm install && \
+    npx shadow-cljs release reljr
+
+FROM node:18-alpine AS main
+
+COPY --from=build /app/public /
+
+ENV PORT=3000
+
+EXPOSE $PORT
+
+ENTRYPOINT exec npx http-server -p $PORT

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,26 @@
+# fly.toml file generated for reljr on 2023-04-08T13:58:15-04:00
+
+app = "reljr"
+kill_signal = "SIGINT"
+kill_timeout = 5
+mounts = []
+primary_region = "mia"
+processes = []
+
+[[services]]
+  internal_port = 3000
+  processes = ["app"]
+  protocol = "tcp"
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="/css/main.css"/>
     <title>Reljr</title>
+    <script defer data-domain="reljr.com" src="https://plausible.io/js/script.js"></script>
   </head>
   <body>
       <!-- Create the div and load the compiled js -->


### PR DESCRIPTION
Migrating off DO for my own stuff, bringing reljr along for the ride to have one less box to update~

Currently deployed at https://reljr.fly.dev/ 

If this all looks good, I'll add the Fly API token to Secrets and set up SSL with fly for the domain.